### PR TITLE
flip fetch_transactions output to ascending by date

### DIFF
--- a/scripts/ychad.py
+++ b/scripts/ychad.py
@@ -129,7 +129,7 @@ def fetch_transactions(address):
                 if str(parsed['from']) == 'ychad.eth':
                     transactions.extend(populate_erc20_transfers(parsed))
 
-    return sorted(transactions, key=itemgetter('date'), reverse=True)
+    return sorted(transactions, key=itemgetter('date'))
 
 
 def write_csv(transactions, out_name):


### PR DESCRIPTION
Fixes: #2 

From what I understand this issue can be solved by simply removing the `reverse=True in the return statement of `fetch_transactions` function in `scripts/ychad.py` (line 132) . Let me know if I missed anything though.